### PR TITLE
Too big a chunk of refactoring and portability fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
-libtermux-exec.so: termux-exec.c
-	$(CC) $(CFLAGS) -Wall -Wextra -Oz termux-exec.c -shared -fPIC -o libtermux-exec.so
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+	CFLAGS += -Oz
+else
+	CFLAGS += -Os
+endif
+
+libtermux-exec.so: termux-exec.c termux_rewrite_executable.c
+	$(CC) $(CFLAGS) $^ -shared -fPIC -o $@
+
+termux-rewrite-exe: termux-rewrite-exe.c termux_rewrite_executable.c
+	$(CC) $(CFLAGS) $^ -o $@
 
 install: libtermux-exec.so
 	install libtermux-exec.so $(PREFIX)/lib/libtermux-exec.so
@@ -11,6 +22,6 @@ test: libtermux-exec.so
 	@LD_PRELOAD=${CURDIR}/libtermux-exec.so ./run-tests.sh
 
 clean:
-	rm -f libtermux-exec.so tests/*-actual
+	rm -f libtermux-exec.so termux-rewrite-exe tests/*-actual
 
 .PHONY: clean install test uninstall

--- a/termux-rewrite-exe.c
+++ b/termux-rewrite-exe.c
@@ -1,0 +1,49 @@
+/*
+  command line test driver
+
+	## command ##
+  $ ./termux-rewrite-exe /bin/sh /usr/bin/env
+	## output ##
+  /data/data/com.termux/files/usr/bin/sh
+  /data/data/com.termux/files/usr/bin/env
+*/
+
+#include "termux_rewrite_executable.h"
+
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+
+int main(int argc, char** argv) {
+	int verbose = 0;
+	size_t idx = 1;
+	for ( ; idx < argc; ++idx ) {
+		if (strcmp("-v", argv[idx]) == 0) {
+		  verbose = 1;
+			continue;
+		}
+		if (strcmp("--", argv[idx]) == 0) {
+			++idx;
+			break;
+		}
+		if (strncmp("-", argv[idx], 1) == 0) {
+			fprintf(stderr, "unrecognized option '%s'", argv[idx]);
+			return 1;
+		}
+
+		break;
+	}
+	const char* fmt[]={
+		"%.0s%s\n",
+		"'%s' -> '%s'\n"
+	};
+
+	char rewritten[512];
+	for( ; idx < argc; ++idx ) {
+		printf(
+			fmt[verbose],
+			argv[idx],
+			termux_rewrite_executable(rewritten, sizeof(rewritten), argv[idx]));
+	}
+	return 0;
+}

--- a/termux_rewrite_executable.c
+++ b/termux_rewrite_executable.c
@@ -1,0 +1,20 @@
+#include "termux_rewrite_executable.h"
+
+#include <string.h>
+#include <stdio.h>
+
+const char* termux_rewrite_executable(
+	char* rewritten, size_t rewritten_size, const char* original)
+{
+	const char* bin_match = strstr(original, "/bin/");
+	// We have either found "/bin/" at the start of the string or at
+	// "/xxx/bin/". Take the path after that.
+	if (bin_match != original && bin_match != (original + 4)) {
+		snprintf(rewritten, rewritten_size, "%s", original);
+		return rewritten;
+	}
+
+	const char termux_usr_bin[]="/data/data/com.termux/files/usr/bin";
+	snprintf(rewritten, rewritten_size, "%s/%s", termux_usr_bin, bin_match + 5);
+	return rewritten;
+}

--- a/termux_rewrite_executable.h
+++ b/termux_rewrite_executable.h
@@ -1,0 +1,11 @@
+#ifndef TERMUX_REWRITE_EXECUTABLE__INCLUDED
+#define TERMUX_REWRITE_EXECUTABLE__INCLUDED
+
+#include <stddef.h>
+
+const char* termux_rewrite_executable(
+  char* rewritten,
+  size_t rewritten_size,
+  const char* original);
+
+#endif // TERMUX_REWRITE_EXECUTABLE__INCLUDED


### PR DESCRIPTION
Added gcc and clang build support for Ubuntu (tested with 17.04).
Added gcc/c4droid build support (tested with Marshmallow).
Added clang/termux build support (tested with marshmallow).
Added command line rewrite driver for testing.
Hopefully, Mac build is fine. I don't have the environment to verify.
Fixed a few potential buffer overrun (I vaguely remember a command could be up to 4k (?) (I could very well be wrong) and strncpy doesn't always NULL-end the string, ref manpage).

I was actually planning/researching on a similar tool, but for native environment. Thanks to this great template, a working prototype took only a few hours. It would most likely end up as a magisk module. Though it wasn't my plan to contribute to termux when I started, but I am a grateful user, so why not.

If ppl like what I did to it, there is more to come. If not, that fine, too. The code and updates will be on github, I just won't be actively sending pull requests.

Cheers,
- kenneth
