### PR TITLE
feat(ld-preload): add standalone `libtermux-paths-ld-preload.so` for `/etc/` file access redirection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ override LIBTERMUX_EXEC__NOS__C__SOURCE_FILES := \
 	lib/termux-exec_nos_c/tre/src/termux/api/termux_exec/service/ld_preload/TermuxExecLDPreload.c \
 	lib/termux-exec_nos_c/tre/src/termux/api/termux_exec/service/ld_preload/direct/exec/ExecIntercept.c \
 	lib/termux-exec_nos_c/tre/src/termux/api/termux_exec/service/ld_preload/direct/exec/ExecVariantsIntercept.c \
+	lib/termux-exec_nos_c/tre/src/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.c \
 	lib/termux-exec_nos_c/tre/src/termux/os/process/termux_exec/TermuxExecProcess.c \
 	lib/termux-exec_nos_c/tre/src/termux/shell/command/environment/termux_exec/TermuxExecShellEnvironment.c
 

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ CLANG_TIDY ?= clang-tidy
 # - https://www.gnu.org/software/make/manual/html_node/Parallel-Disable.html
 .NOTPARALLEL:
 
-all: | pre-build build-libtermux-exec_nos_c_tre build-libtermux-exec-direct-ld-preload build-libtermux-exec-linker-ld-preload build-termux-exec-main-app
+all: | pre-build build-libtermux-exec_nos_c_tre build-libtermux-exec-direct-ld-preload build-libtermux-exec-linker-ld-preload build-libtermux-paths-ld-preload build-termux-exec-main-app
 	@printf "\ntermux-exec-package: %s\n" "Building packaging/debian/*"
 	@mkdir -p $(DEBIAN_PACKAGING_BUILD_OUTPUT_DIR)
 	find packaging/debian -mindepth 1 -maxdepth 1 -type f -name "*.in" -exec sh -c \
@@ -438,6 +438,24 @@ build-libtermux-exec-linker-ld-preload:
 		app/termux-exec-linker-ld-preload/src/termux/api/termux_exec/service/ld_preload/linker/TermuxExecLinkerLDPreloadEntryPoint.c \
 		-l:libtermux-exec_nos_c_tre.a -l:libtermux-core_nos_c_tre.a
 
+build-libtermux-paths-ld-preload:
+	@mkdir -p $(LIB_BUILD_OUTPUT_DIR)
+
+	@# Unlike `libtermux-exec_nos_c_tre.so` and `libtermux-exec_nos_c_tre.a`, all
+	@# symbols are hidden, except the exported functions with
+	@# `default` visibility with `__attribute__((visibility("default")))`,
+	@# defined in the `TermuxPathsLDPreloadEntryPoint.c` file meant to
+	@# be intercepted by `$LD_PRELOAD`.
+	@# `nm --demangle --dynamic --defined-only --extern-only /home/builder/.termux-build/termux-exec/src/build/output/usr/lib/libtermux-paths-ld-preload.so`
+	@printf "\ntermux-exec-package: %s\n" "Building lib/libtermux-paths-ld-preload"
+	$(CC) $(CFLAGS) $(LIBTERMUX_EXEC__NOS__C__CPPFLAGS) \
+		-L$(LIB_BUILD_OUTPUT_DIR) $(LDFLAGS) -Wl,--exclude-libs=ALL \
+		$(TERMUX__CONSTANTS__MACRO_FLAGS) \
+		-fPIC -shared -fvisibility=hidden \
+		-o $(LIB_BUILD_OUTPUT_DIR)/libtermux-paths-ld-preload.so \
+		app/termux-paths-ld-preload/src/termux/api/termux_exec/service/ld_preload/paths/TermuxPathsLDPreloadEntryPoint.c \
+		-l:libtermux-exec_nos_c_tre.a -l:libtermux-core_nos_c_tre.a
+
 
 
 clean:
@@ -463,6 +481,7 @@ install:
 	install $(LIB_BUILD_OUTPUT_DIR)/libtermux-exec-ld-preload.so $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec-ld-preload.so
 	install $(LIB_BUILD_OUTPUT_DIR)/libtermux-exec-direct-ld-preload.so $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec-direct-ld-preload.so
 	install $(LIB_BUILD_OUTPUT_DIR)/libtermux-exec-linker-ld-preload.so $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec-linker-ld-preload.so
+	install $(LIB_BUILD_OUTPUT_DIR)/libtermux-paths-ld-preload.so $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-paths-ld-preload.so
 	@# Use `cp` for symlink as `install` will copy the target regular file instead.
 	cp -a $(LIB_BUILD_OUTPUT_DIR)/libtermux-exec.so $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec.so
 
@@ -491,6 +510,7 @@ uninstall:
 	rm -f $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec-ld-preload.so
 	rm -f $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec-direct-ld-preload.so
 	rm -f $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec-linker-ld-preload.so
+	rm -f $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-paths-ld-preload.so
 	rm -f $(TERMUX_EXEC_PKG__INSTALL_PREFIX)/lib/libtermux-exec.so
 
 
@@ -534,14 +554,14 @@ test-runtime: all
 
 
 format:
-	$(CLANG_FORMAT) -i app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c $(LIBTERMUX_EXEC__NOS__C__SOURCE_FILES)
+	$(CLANG_FORMAT) -i app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c app/termux-paths-ld-preload/src/termux/api/termux_exec/service/ld_preload/paths/TermuxPathsLDPreloadEntryPoint.c $(LIBTERMUX_EXEC__NOS__C__SOURCE_FILES)
 check:
-	$(CLANG_FORMAT) --dry-run app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c $(LIBTERMUX_EXEC__NOS__C__SOURCE_FILES)
+	$(CLANG_FORMAT) --dry-run app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c app/termux-paths-ld-preload/src/termux/api/termux_exec/service/ld_preload/paths/TermuxPathsLDPreloadEntryPoint.c $(LIBTERMUX_EXEC__NOS__C__SOURCE_FILES)
 	$(CLANG_TIDY) -warnings-as-errors='*' \
-		app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c $(LIBTERMUX_EXEC__NOS__C__SOURCE_FILES) -- \
+		app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c app/termux-paths-ld-preload/src/termux/api/termux_exec/service/ld_preload/paths/TermuxPathsLDPreloadEntryPoint.c $(LIBTERMUX_EXEC__NOS__C__SOURCE_FILES) -- \
 		$(LIBTERMUX_EXEC__NOS__C__CPPFLAGS) \
 		$(TERMUX__CONSTANTS__MACRO_FLAGS)
 
 
 
-.PHONY: all pre-build build-termux-exec-main-app build-libtermux-exec_nos_c_tre build-libtermux-exec_nos_c_tre_runtime-binary-tests build-libtermux-exec-linker-ld-preload build-libtermux-exec-direct-ld-preload clean install uninstall packaging-debian-build test test-unit test-runtime format check
+.PHONY: all pre-build build-termux-exec-main-app build-libtermux-exec_nos_c_tre build-libtermux-exec_nos_c_tre_runtime-binary-tests build-libtermux-exec-linker-ld-preload build-libtermux-exec-direct-ld-preload build-libtermux-paths-ld-preload clean install uninstall packaging-debian-build test test-unit test-runtime format check

--- a/app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c
+++ b/app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c
@@ -1,17 +1,10 @@
 #define _GNU_SOURCE
-#include <dlfcn.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <linux/limits.h>
 #include <stdarg.h>
 #include <stdbool.h>
-#include <stdio.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/exec/ExecIntercept.h>
 #include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/exec/ExecVariantsIntercept.h>
-#include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h>
 #include <termux/termux_exec__nos__c/v1/termux/os/process/termux_exec/TermuxExecProcess.h>
 
 /**
@@ -103,118 +96,4 @@ int execve(const char *name, char *const argv[], char *const envp[]) {
     termuxExec_directLdPreload_initProcess();
 
     return execveIntercept(true, name, argv, envp);
-}
-
-
-
-/*
- * File access interceptors for `/etc/` path redirection.
- *
- * These intercept libc file-access functions and redirect accesses of
- * standard Linux `/etc/` configuration files (resolv.conf, hosts,
- * nsswitch.conf, SSL CA certificates) to their Termux equivalents
- * under `$PREFIX/etc/`. All access modes (read, write, stat) are
- * redirected so that programs see a consistent view of these paths.
- *
- * This fixes DNS resolution and TLS certificate verification for
- * dynamically linked programs on Termux, where Android does not
- * provide these files at their standard paths.
- */
-
-typedef int     (*orig_open_fn)(const char *, int, ...);
-typedef int     (*orig_openat_fn)(int, const char *, int, ...);
-typedef FILE   *(*orig_fopen_fn)(const char *, const char *);
-typedef int     (*orig_access_fn)(const char *, int);
-typedef int     (*orig_faccessat_fn)(int, const char *, int, int);
-typedef int     (*orig_stat_fn)(const char *, struct stat *);
-typedef int     (*orig_lstat_fn)(const char *, struct stat *);
-
-static orig_open_fn      real_open;
-static orig_openat_fn    real_openat;
-static orig_fopen_fn     real_fopen;
-static orig_access_fn    real_access;
-static orig_faccessat_fn real_faccessat;
-static orig_stat_fn      real_stat;
-static orig_lstat_fn     real_lstat;
-
-/** Resolve real libc symbols at load time for thread safety. */
-__attribute__((constructor))
-static void initFileInterceptRealFunctions(void) {
-    real_open      = (orig_open_fn)dlsym(RTLD_NEXT, "open");
-    real_openat    = (orig_openat_fn)dlsym(RTLD_NEXT, "openat");
-    real_fopen     = (orig_fopen_fn)dlsym(RTLD_NEXT, "fopen");
-    real_access    = (orig_access_fn)dlsym(RTLD_NEXT, "access");
-    real_faccessat = (orig_faccessat_fn)dlsym(RTLD_NEXT, "faccessat");
-    real_stat      = (orig_stat_fn)dlsym(RTLD_NEXT, "stat");
-    real_lstat     = (orig_lstat_fn)dlsym(RTLD_NEXT, "lstat");
-}
-
-__attribute__((visibility("default")))
-int open(const char *pathname, int flags, ...) {
-    if (!real_open) { errno = ENOSYS; return -1; }
-    char buf[PATH_MAX];
-    const char *p = fileAccess_redirectPath(pathname, buf, sizeof(buf));
-    if (flags & (O_CREAT | O_TMPFILE)) {
-        va_list ap;
-        va_start(ap, flags);
-        mode_t mode = (mode_t)va_arg(ap, int);
-        va_end(ap);
-        return real_open(p, flags, mode);
-    }
-    return real_open(p, flags);
-}
-
-__attribute__((visibility("default")))
-int openat(int dirfd, const char *pathname, int flags, ...) {
-    if (!real_openat) { errno = ENOSYS; return -1; }
-    char buf[PATH_MAX];
-    const char *p = (pathname && pathname[0] == '/')
-                    ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
-                    : pathname;
-    if (flags & (O_CREAT | O_TMPFILE)) {
-        va_list ap;
-        va_start(ap, flags);
-        mode_t mode = (mode_t)va_arg(ap, int);
-        va_end(ap);
-        return real_openat(dirfd, p, flags, mode);
-    }
-    return real_openat(dirfd, p, flags);
-}
-
-__attribute__((visibility("default")))
-FILE *fopen(const char *pathname, const char *mode) {
-    if (!real_fopen) { errno = ENOSYS; return NULL; }
-    char buf[PATH_MAX];
-    return real_fopen(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
-}
-
-__attribute__((visibility("default")))
-int access(const char *pathname, int mode) {
-    if (!real_access) { errno = ENOSYS; return -1; }
-    char buf[PATH_MAX];
-    return real_access(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
-}
-
-__attribute__((visibility("default")))
-int faccessat(int dirfd, const char *pathname, int mode, int flags) {
-    if (!real_faccessat) { errno = ENOSYS; return -1; }
-    char buf[PATH_MAX];
-    const char *p = (pathname && pathname[0] == '/')
-                    ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
-                    : pathname;
-    return real_faccessat(dirfd, p, mode, flags);
-}
-
-__attribute__((visibility("default")))
-int stat(const char *restrict pathname, struct stat *restrict statbuf) {
-    if (!real_stat) { errno = ENOSYS; return -1; }
-    char buf[PATH_MAX];
-    return real_stat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
-}
-
-__attribute__((visibility("default")))
-int lstat(const char *restrict pathname, struct stat *restrict statbuf) {
-    if (!real_lstat) { errno = ENOSYS; return -1; }
-    char buf[PATH_MAX];
-    return real_lstat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
 }

--- a/app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c
+++ b/app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include <dlfcn.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <linux/limits.h>
 #include <stdarg.h>
@@ -109,10 +110,11 @@ int execve(const char *name, char *const argv[], char *const envp[]) {
 /*
  * File access interceptors for `/etc/` path redirection.
  *
- * These intercept libc file-access functions and redirect reads of
+ * These intercept libc file-access functions and redirect accesses of
  * standard Linux `/etc/` configuration files (resolv.conf, hosts,
  * nsswitch.conf, SSL CA certificates) to their Termux equivalents
- * under `$PREFIX/etc/`.
+ * under `$PREFIX/etc/`. All access modes (read, write, stat) are
+ * redirected so that programs see a consistent view of these paths.
  *
  * This fixes DNS resolution and TLS certificate verification for
  * dynamically linked programs on Termux, where Android does not
@@ -135,13 +137,21 @@ static orig_faccessat_fn real_faccessat;
 static orig_stat_fn      real_stat;
 static orig_lstat_fn     real_lstat;
 
-#define LOAD_REAL(name) do { \
-    if (!real_##name) real_##name = (orig_##name##_fn)dlsym(RTLD_NEXT, #name); \
-} while (0)
+/** Resolve real libc symbols at load time for thread safety. */
+__attribute__((constructor))
+static void initFileInterceptRealFunctions(void) {
+    real_open      = (orig_open_fn)dlsym(RTLD_NEXT, "open");
+    real_openat    = (orig_openat_fn)dlsym(RTLD_NEXT, "openat");
+    real_fopen     = (orig_fopen_fn)dlsym(RTLD_NEXT, "fopen");
+    real_access    = (orig_access_fn)dlsym(RTLD_NEXT, "access");
+    real_faccessat = (orig_faccessat_fn)dlsym(RTLD_NEXT, "faccessat");
+    real_stat      = (orig_stat_fn)dlsym(RTLD_NEXT, "stat");
+    real_lstat     = (orig_lstat_fn)dlsym(RTLD_NEXT, "lstat");
+}
 
 __attribute__((visibility("default")))
 int open(const char *pathname, int flags, ...) {
-    LOAD_REAL(open);
+    if (!real_open) { errno = ENOSYS; return -1; }
     char buf[PATH_MAX];
     const char *p = fileAccess_redirectPath(pathname, buf, sizeof(buf));
     if (flags & (O_CREAT | O_TMPFILE)) {
@@ -156,7 +166,7 @@ int open(const char *pathname, int flags, ...) {
 
 __attribute__((visibility("default")))
 int openat(int dirfd, const char *pathname, int flags, ...) {
-    LOAD_REAL(openat);
+    if (!real_openat) { errno = ENOSYS; return -1; }
     char buf[PATH_MAX];
     const char *p = (pathname && pathname[0] == '/')
                     ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
@@ -173,21 +183,21 @@ int openat(int dirfd, const char *pathname, int flags, ...) {
 
 __attribute__((visibility("default")))
 FILE *fopen(const char *pathname, const char *mode) {
-    LOAD_REAL(fopen);
+    if (!real_fopen) { errno = ENOSYS; return NULL; }
     char buf[PATH_MAX];
     return real_fopen(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
 }
 
 __attribute__((visibility("default")))
 int access(const char *pathname, int mode) {
-    LOAD_REAL(access);
+    if (!real_access) { errno = ENOSYS; return -1; }
     char buf[PATH_MAX];
     return real_access(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
 }
 
 __attribute__((visibility("default")))
 int faccessat(int dirfd, const char *pathname, int mode, int flags) {
-    LOAD_REAL(faccessat);
+    if (!real_faccessat) { errno = ENOSYS; return -1; }
     char buf[PATH_MAX];
     const char *p = (pathname && pathname[0] == '/')
                     ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
@@ -197,14 +207,14 @@ int faccessat(int dirfd, const char *pathname, int mode, int flags) {
 
 __attribute__((visibility("default")))
 int stat(const char *restrict pathname, struct stat *restrict statbuf) {
-    LOAD_REAL(stat);
+    if (!real_stat) { errno = ENOSYS; return -1; }
     char buf[PATH_MAX];
     return real_stat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
 }
 
 __attribute__((visibility("default")))
 int lstat(const char *restrict pathname, struct stat *restrict statbuf) {
-    LOAD_REAL(lstat);
+    if (!real_lstat) { errno = ENOSYS; return -1; }
     char buf[PATH_MAX];
     return real_lstat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
 }

--- a/app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c
+++ b/app/termux-exec-direct-ld-preload/src/termux/api/termux_exec/service/ld_preload/direct/TermuxExecDirectLDPreloadEntryPoint.c
@@ -1,10 +1,16 @@
 #define _GNU_SOURCE
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <linux/limits.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/exec/ExecIntercept.h>
 #include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/exec/ExecVariantsIntercept.h>
+#include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h>
 #include <termux/termux_exec__nos__c/v1/termux/os/process/termux_exec/TermuxExecProcess.h>
 
 /**
@@ -96,4 +102,109 @@ int execve(const char *name, char *const argv[], char *const envp[]) {
     termuxExec_directLdPreload_initProcess();
 
     return execveIntercept(true, name, argv, envp);
+}
+
+
+
+/*
+ * File access interceptors for `/etc/` path redirection.
+ *
+ * These intercept libc file-access functions and redirect reads of
+ * standard Linux `/etc/` configuration files (resolv.conf, hosts,
+ * nsswitch.conf, SSL CA certificates) to their Termux equivalents
+ * under `$PREFIX/etc/`.
+ *
+ * This fixes DNS resolution and TLS certificate verification for
+ * dynamically linked programs on Termux, where Android does not
+ * provide these files at their standard paths.
+ */
+
+typedef int     (*orig_open_fn)(const char *, int, ...);
+typedef int     (*orig_openat_fn)(int, const char *, int, ...);
+typedef FILE   *(*orig_fopen_fn)(const char *, const char *);
+typedef int     (*orig_access_fn)(const char *, int);
+typedef int     (*orig_faccessat_fn)(int, const char *, int, int);
+typedef int     (*orig_stat_fn)(const char *, struct stat *);
+typedef int     (*orig_lstat_fn)(const char *, struct stat *);
+
+static orig_open_fn      real_open;
+static orig_openat_fn    real_openat;
+static orig_fopen_fn     real_fopen;
+static orig_access_fn    real_access;
+static orig_faccessat_fn real_faccessat;
+static orig_stat_fn      real_stat;
+static orig_lstat_fn     real_lstat;
+
+#define LOAD_REAL(name) do { \
+    if (!real_##name) real_##name = (orig_##name##_fn)dlsym(RTLD_NEXT, #name); \
+} while (0)
+
+__attribute__((visibility("default")))
+int open(const char *pathname, int flags, ...) {
+    LOAD_REAL(open);
+    char buf[PATH_MAX];
+    const char *p = fileAccess_redirectPath(pathname, buf, sizeof(buf));
+    if (flags & (O_CREAT | O_TMPFILE)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode_t mode = (mode_t)va_arg(ap, int);
+        va_end(ap);
+        return real_open(p, flags, mode);
+    }
+    return real_open(p, flags);
+}
+
+__attribute__((visibility("default")))
+int openat(int dirfd, const char *pathname, int flags, ...) {
+    LOAD_REAL(openat);
+    char buf[PATH_MAX];
+    const char *p = (pathname && pathname[0] == '/')
+                    ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
+                    : pathname;
+    if (flags & (O_CREAT | O_TMPFILE)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode_t mode = (mode_t)va_arg(ap, int);
+        va_end(ap);
+        return real_openat(dirfd, p, flags, mode);
+    }
+    return real_openat(dirfd, p, flags);
+}
+
+__attribute__((visibility("default")))
+FILE *fopen(const char *pathname, const char *mode) {
+    LOAD_REAL(fopen);
+    char buf[PATH_MAX];
+    return real_fopen(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
+}
+
+__attribute__((visibility("default")))
+int access(const char *pathname, int mode) {
+    LOAD_REAL(access);
+    char buf[PATH_MAX];
+    return real_access(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
+}
+
+__attribute__((visibility("default")))
+int faccessat(int dirfd, const char *pathname, int mode, int flags) {
+    LOAD_REAL(faccessat);
+    char buf[PATH_MAX];
+    const char *p = (pathname && pathname[0] == '/')
+                    ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
+                    : pathname;
+    return real_faccessat(dirfd, p, mode, flags);
+}
+
+__attribute__((visibility("default")))
+int stat(const char *restrict pathname, struct stat *restrict statbuf) {
+    LOAD_REAL(stat);
+    char buf[PATH_MAX];
+    return real_stat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
+}
+
+__attribute__((visibility("default")))
+int lstat(const char *restrict pathname, struct stat *restrict statbuf) {
+    LOAD_REAL(lstat);
+    char buf[PATH_MAX];
+    return real_lstat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
 }

--- a/app/termux-paths-ld-preload/src/termux/api/termux_exec/service/ld_preload/paths/TermuxPathsLDPreloadEntryPoint.c
+++ b/app/termux-paths-ld-preload/src/termux/api/termux_exec/service/ld_preload/paths/TermuxPathsLDPreloadEntryPoint.c
@@ -1,0 +1,140 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h>
+
+/**
+ * This file defines functions intercepted by `libtermux-paths-ld-preload.so` using `$LD_PRELOAD`.
+ *
+ * All exported functions must explicitly enable `default` visibility
+ * with `__attribute__((visibility("default")))` as `libtermux-paths-ld-preload.so`
+ * is compiled with `-fvisibility=hidden` so that no other internal
+ * functions are exported.
+ *
+ * You can check exported symbols for dynamic linking after building with:
+ * `nm --demangle --dynamic --defined-only --extern-only /home/builder/.termux-build/termux-exec/src/build/output/usr/lib/libtermux-paths-ld-preload.so`.
+ */
+
+#define LIBTERMUX_PATHS_LD_PRELOAD__VERSION_NAME TERMUX_EXEC_PKG__VERSION
+#define LIBTERMUX_PATHS_LD_PRELOAD__VERSION_STRING "libtermux-paths-ld-preload version=" LIBTERMUX_PATHS_LD_PRELOAD__VERSION_NAME " org=" TERMUX__REPOS_HOST_ORG_NAME " project=termux-exec-package"
+
+
+
+/*
+ * File access interceptors for `/etc/` path redirection.
+ *
+ * These intercept libc file-access functions and redirect accesses of
+ * standard Linux `/etc/` configuration files (resolv.conf, hosts,
+ * nsswitch.conf, SSL CA certificates) to their Termux equivalents
+ * under `$PREFIX/etc/`. All access modes (read, write, stat) are
+ * redirected so that programs see a consistent view of these paths.
+ *
+ * This fixes DNS resolution and TLS certificate verification for
+ * dynamically linked programs on Termux, where Android does not
+ * provide these files at their standard paths.
+ */
+
+typedef int     (*orig_open_fn)(const char *, int, ...);
+typedef int     (*orig_openat_fn)(int, const char *, int, ...);
+typedef FILE   *(*orig_fopen_fn)(const char *, const char *);
+typedef int     (*orig_access_fn)(const char *, int);
+typedef int     (*orig_faccessat_fn)(int, const char *, int, int);
+typedef int     (*orig_stat_fn)(const char *, struct stat *);
+typedef int     (*orig_lstat_fn)(const char *, struct stat *);
+
+static orig_open_fn      real_open;
+static orig_openat_fn    real_openat;
+static orig_fopen_fn     real_fopen;
+static orig_access_fn    real_access;
+static orig_faccessat_fn real_faccessat;
+static orig_stat_fn      real_stat;
+static orig_lstat_fn     real_lstat;
+
+/** Resolve real libc symbols at load time for thread safety. */
+__attribute__((constructor))
+static void initFileInterceptRealFunctions(void) {
+    real_open      = (orig_open_fn)dlsym(RTLD_NEXT, "open");
+    real_openat    = (orig_openat_fn)dlsym(RTLD_NEXT, "openat");
+    real_fopen     = (orig_fopen_fn)dlsym(RTLD_NEXT, "fopen");
+    real_access    = (orig_access_fn)dlsym(RTLD_NEXT, "access");
+    real_faccessat = (orig_faccessat_fn)dlsym(RTLD_NEXT, "faccessat");
+    real_stat      = (orig_stat_fn)dlsym(RTLD_NEXT, "stat");
+    real_lstat     = (orig_lstat_fn)dlsym(RTLD_NEXT, "lstat");
+}
+
+__attribute__((visibility("default")))
+int open(const char *pathname, int flags, ...) {
+    if (!real_open) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    const char *p = fileAccess_redirectPath(pathname, buf, sizeof(buf));
+    if (flags & (O_CREAT | O_TMPFILE)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode_t mode = (mode_t)va_arg(ap, int);
+        va_end(ap);
+        return real_open(p, flags, mode);
+    }
+    return real_open(p, flags);
+}
+
+__attribute__((visibility("default")))
+int openat(int dirfd, const char *pathname, int flags, ...) {
+    if (!real_openat) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    const char *p = (pathname && pathname[0] == '/')
+                    ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
+                    : pathname;
+    if (flags & (O_CREAT | O_TMPFILE)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode_t mode = (mode_t)va_arg(ap, int);
+        va_end(ap);
+        return real_openat(dirfd, p, flags, mode);
+    }
+    return real_openat(dirfd, p, flags);
+}
+
+__attribute__((visibility("default")))
+FILE *fopen(const char *pathname, const char *mode) {
+    if (!real_fopen) { errno = ENOSYS; return NULL; }
+    char buf[PATH_MAX];
+    return real_fopen(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
+}
+
+__attribute__((visibility("default")))
+int access(const char *pathname, int mode) {
+    if (!real_access) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    return real_access(fileAccess_redirectPath(pathname, buf, sizeof(buf)), mode);
+}
+
+__attribute__((visibility("default")))
+int faccessat(int dirfd, const char *pathname, int mode, int flags) {
+    if (!real_faccessat) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    const char *p = (pathname && pathname[0] == '/')
+                    ? fileAccess_redirectPath(pathname, buf, sizeof(buf))
+                    : pathname;
+    return real_faccessat(dirfd, p, mode, flags);
+}
+
+__attribute__((visibility("default")))
+int stat(const char *restrict pathname, struct stat *restrict statbuf) {
+    if (!real_stat) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    return real_stat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
+}
+
+__attribute__((visibility("default")))
+int lstat(const char *restrict pathname, struct stat *restrict statbuf) {
+    if (!real_lstat) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    return real_lstat(fileAccess_redirectPath(pathname, buf, sizeof(buf)), statbuf);
+}

--- a/lib/termux-exec_nos_c/tre/include/termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h
+++ b/lib/termux-exec_nos_c/tre/include/termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h
@@ -23,20 +23,22 @@ typedef struct {
 /**
  * Check if `path` should be redirected to a Termux prefix equivalent.
  *
- * Redirects reads of standard Linux `/etc/` configuration files to
- * their Termux equivalents under `$TERMUX__PREFIX/etc/`. This is needed
- * because Android does not provide `/etc/resolv.conf`,
- * `/etc/nsswitch.conf`, or standard SSL certificate paths.
+ * Redirects accesses of standard Linux `/etc/` configuration files to
+ * their Termux equivalents under `$TERMUX__PREFIX/etc/`. All access
+ * modes (read, write, stat) are redirected. This is needed because
+ * Android does not provide `/etc/resolv.conf`, `/etc/nsswitch.conf`,
+ * or standard SSL certificate paths.
  *
  * Currently redirected:
  * - `/etc/resolv.conf`       -> `$PREFIX/etc/resolv.conf`
  * - `/etc/hosts`             -> `$PREFIX/etc/hosts`
  * - `/etc/nsswitch.conf`     -> `$PREFIX/etc/nsswitch.conf`
- * - `/etc/ssl/certs/ca-certificates.crt` -> `$PREFIX/etc/tls/cert.pem`
- * - `/etc/pki/tls/certs/ca-bundle.crt`   -> `$PREFIX/etc/tls/cert.pem`
- * - `/etc/ssl/ca-bundle.pem`             -> `$PREFIX/etc/tls/cert.pem`
- * - `/etc/pki/tls/cacert.pem`            -> `$PREFIX/etc/tls/cert.pem`
- * - `/etc/ssl/cert.pem`                  -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/ssl/certs/ca-certificates.crt`              -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/pki/tls/certs/ca-bundle.crt`                -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/ssl/ca-bundle.pem`                          -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/pki/tls/cacert.pem`                         -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/ssl/cert.pem`                               -> `$PREFIX/etc/tls/cert.pem`
  *
  * @param path The path being accessed.
  * @param buffer Output buffer for the redirected path (should be PATH_MAX).

--- a/lib/termux-exec_nos_c/tre/include/termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h
+++ b/lib/termux-exec_nos_c/tre/include/termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h
@@ -1,0 +1,55 @@
+#ifndef LIBTERMUX_EXEC__NOS__C__FILE_ACCESS_INTERCEPT___H
+#define LIBTERMUX_EXEC__NOS__C__FILE_ACCESS_INTERCEPT___H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/**
+ * Redirect table entry: maps a source path to a destination path
+ * relative to the Termux prefix directory.
+ */
+typedef struct {
+    const char *src;  /** Path the program tries to access (e.g. "/etc/resolv.conf"). */
+    const char *dest; /** Path relative to $PREFIX to redirect to (e.g. "/etc/resolv.conf"). */
+} FileAccessRedirectEntry;
+
+
+
+/**
+ * Check if `path` should be redirected to a Termux prefix equivalent.
+ *
+ * Redirects reads of standard Linux `/etc/` configuration files to
+ * their Termux equivalents under `$TERMUX__PREFIX/etc/`. This is needed
+ * because Android does not provide `/etc/resolv.conf`,
+ * `/etc/nsswitch.conf`, or standard SSL certificate paths.
+ *
+ * Currently redirected:
+ * - `/etc/resolv.conf`       -> `$PREFIX/etc/resolv.conf`
+ * - `/etc/hosts`             -> `$PREFIX/etc/hosts`
+ * - `/etc/nsswitch.conf`     -> `$PREFIX/etc/nsswitch.conf`
+ * - `/etc/ssl/certs/ca-certificates.crt` -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/pki/tls/certs/ca-bundle.crt`   -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/ssl/ca-bundle.pem`             -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/pki/tls/cacert.pem`            -> `$PREFIX/etc/tls/cert.pem`
+ * - `/etc/ssl/cert.pem`                  -> `$PREFIX/etc/tls/cert.pem`
+ *
+ * @param path The path being accessed.
+ * @param buffer Output buffer for the redirected path (should be PATH_MAX).
+ * @param bufferSize Size of the output buffer.
+ * @return The redirected path if applicable, otherwise the original path.
+ */
+const char *fileAccess_redirectPath(const char *path,
+    char *buffer, size_t bufferSize);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBTERMUX_EXEC__NOS__C__FILE_ACCESS_INTERCEPT___H */

--- a/lib/termux-exec_nos_c/tre/src/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.c
+++ b/lib/termux-exec_nos_c/tre/src/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.c
@@ -1,0 +1,59 @@
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <linux/limits.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <termux/termux_core__nos__c/v1/termux/file/TermuxFile.h>
+#include <termux/termux_exec__nos__c/v1/termux/api/termux_exec/service/ld_preload/direct/file/FileAccessIntercept.h>
+
+/**
+ * Redirect table for standard Linux `/etc/` files to Termux prefix equivalents.
+ *
+ * For SSL certificates, Go's `crypto/x509/root_linux.go` checks several
+ * hardcoded paths. We redirect them all to Termux's cert bundle at
+ * `$PREFIX/etc/tls/cert.pem`.
+ */
+static const FileAccessRedirectEntry REDIRECT_TABLE[] = {
+    /* DNS and network configuration */
+    { "/etc/resolv.conf",       "/etc/resolv.conf" },
+    { "/etc/hosts",             "/etc/hosts" },
+    { "/etc/nsswitch.conf",     "/etc/nsswitch.conf" },
+    /* SSL CA certificates */
+    { "/etc/ssl/certs/ca-certificates.crt", "/etc/tls/cert.pem" },
+    { "/etc/pki/tls/certs/ca-bundle.crt",   "/etc/tls/cert.pem" },
+    { "/etc/ssl/ca-bundle.pem",              "/etc/tls/cert.pem" },
+    { "/etc/pki/tls/cacert.pem",             "/etc/tls/cert.pem" },
+    { "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", "/etc/tls/cert.pem" },
+    { "/etc/ssl/cert.pem",                   "/etc/tls/cert.pem" },
+    { NULL, NULL }
+};
+
+const char *fileAccess_redirectPath(const char *path,
+    char *buffer, size_t bufferSize) {
+    if (path == NULL || path[0] != '/') return path;
+
+    for (int i = 0; REDIRECT_TABLE[i].src != NULL; i++) {
+        if (strcmp(path, REDIRECT_TABLE[i].src) != 0) continue;
+
+        const char *prefixDir = termux_prefixDir_get("FileAccessIntercept");
+        if (prefixDir == NULL) return path;
+
+        size_t prefixLen = strlen(prefixDir);
+        size_t destLen = strlen(REDIRECT_TABLE[i].dest);
+        if (prefixLen + destLen + 1 > bufferSize) return path;
+
+        memcpy(buffer, prefixDir, prefixLen);
+        memcpy(buffer + prefixLen, REDIRECT_TABLE[i].dest, destLen + 1);
+
+        /* Only redirect if the Termux file exists.
+         * Use raw syscall to avoid recursing into our own hook. */
+        if (syscall(__NR_faccessat, AT_FDCWD, buffer, F_OK, 0) == 0)
+            return buffer;
+
+        return path;
+    }
+
+    return path;
+}


### PR DESCRIPTION
## Summary

- Added `FileAccessIntercept` module that redirects accesses of standard Linux `/etc/` configuration files to their Termux `$PREFIX/etc/` equivalents
- Added interceptors for `open`, `openat`, `fopen`, `access`, `faccessat`, `stat`, and `lstat` in a **separate, opt-in** `LD_PRELOAD` library (`libtermux-paths-ld-preload.so`)
- Redirected `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf` for DNS resolution
- Redirected Go's hardcoded SSL CA certificate paths to `$PREFIX/etc/tls/cert.pem`
- The `libtermux-exec-direct-ld-preload.so` remains **exec-only** — file access interception is fully decoupled

## Problem

On Android/Termux, standard Linux paths like `/etc/resolv.conf`, `/etc/hosts`, and `/etc/ssl/certs/` either don't exist or contain incomplete data. Termux maintains proper versions under `$PREFIX/etc/`, but many dynamically linked programs hardcode the standard `/etc/` paths.

This causes DNS resolution failures and TLS certificate verification errors for tools like Python, Node.js, and cgo-enabled Go programs running in Termux.

## Solution

Introduce a new **standalone** `libtermux-paths-ld-preload.so` library that intercepts file-access libc functions (`open`, `openat`, `fopen`, `access`, `faccessat`, `stat`, `lstat`) and redirects a fixed set of `/etc/` paths to their `$PREFIX/etc/` equivalents.

This library is **separate from `termux-exec`** and fully opt-in. Users enable it by adding it to `LD_PRELOAD`:

```bash
LD_PRELOAD=libtermux-exec-ld-preload.so:libtermux-paths-ld-preload.so
```

Or standalone (without exec interception):

```bash
LD_PRELOAD=libtermux-paths-ld-preload.so
```

The redirect only applies when:
1. The path exactly matches one of the entries in the redirect table
2. The corresponding Termux file exists (checked via raw `faccessat` syscall to avoid recursion)

### Architecture

The redirect logic (`fileAccess_redirectPath()`) lives in the shared library `libtermux-exec_nos_c_tre` and is reusable. The new entry point (`TermuxPathsLDPreloadEntryPoint.c`) provides the `LD_PRELOAD` hooks that call this logic. The existing `TermuxExecDirectLDPreloadEntryPoint.c` remains unchanged from upstream — exec-only.

```
libtermux-exec_nos_c_tre.a
├── FileAccessIntercept.c    (redirect logic, reusable)
├── ExecIntercept.c          (exec logic)
└── ...

libtermux-exec-direct-ld-preload.so  (exec-only, unchanged)
└── TermuxExecDirectLDPreloadEntryPoint.c

libtermux-paths-ld-preload.so        (file access only, NEW)
└── TermuxPathsLDPreloadEntryPoint.c
```

### Redirected paths

| Source | Destination |
|--------|-------------|
| `/etc/resolv.conf` | `$PREFIX/etc/resolv.conf` |
| `/etc/hosts` | `$PREFIX/etc/hosts` |
| `/etc/nsswitch.conf` | `$PREFIX/etc/nsswitch.conf` |
| `/etc/ssl/certs/ca-certificates.crt` | `$PREFIX/etc/tls/cert.pem` |
| `/etc/pki/tls/certs/ca-bundle.crt` | `$PREFIX/etc/tls/cert.pem` |
| `/etc/ssl/ca-bundle.pem` | `$PREFIX/etc/tls/cert.pem` |
| `/etc/pki/tls/cacert.pem` | `$PREFIX/etc/tls/cert.pem` |
| `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` | `$PREFIX/etc/tls/cert.pem` |
| `/etc/ssl/cert.pem` | `$PREFIX/etc/tls/cert.pem` |

## Limitations

This only fixes **dynamically linked** programs. Statically linked Go binaries (e.g., `terraform`, `gh`, `kubectl`) use raw syscalls and bypass libc entirely — they require a different solution (seccomp `user_notif` or proot).

## Test plan

- [ ] Verify `fopen("/etc/resolv.conf")` returns Termux content
- [ ] Verify `fopen("/etc/hosts")` returns Termux content
- [ ] Verify `open("/etc/ssl/certs/ca-certificates.crt")` returns Termux cert bundle
- [ ] Verify unrelated `/etc/` paths (e.g., `/etc/passwd`) are NOT redirected
- [ ] Verify no regression in existing `execve()` interception tests
- [ ] Verify `libtermux-exec-direct-ld-preload.so` exports only exec symbols
- [ ] Verify `libtermux-paths-ld-preload.so` exports only file access symbols

Closes https://github.com/termux/termux-packages/issues/10277
